### PR TITLE
Template for groups to indicate they do not plan to meet

### DIFF
--- a/.github/ISSUE_TEMPLATE/not-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/not-meeting.yml
@@ -13,6 +13,6 @@ body:
     attributes:
       label: Comments for the W3C staff (Optional)
       description: |
-        If you wish to share any information with the W3C staff about your group's decision not to meet during TPAC, please use the space below.
+        If you wish to share any information about your group's decision not to meet during TPAC, please use the space below.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/not-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/not-meeting.yml
@@ -1,0 +1,18 @@
+name: Group not meeting
+description: Let the W3C staff know your group is not planning to meet.
+labels: ["not-meeting"]
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        Please use this form to let the W3C staff know your group is not planning to meet during TPAC. The title should be the name of the group. The name must be the official [group name in the W3C system](https://www.w3.org/groups/), with some abbreviations supported (e.g., WG for Working Group). 
+
+- type: textarea
+    id: comments
+    attributes:
+      label: Comments for the W3C staff (Optional)
+      description: |
+        If you wish to share any information with the W3C staff about your group's decision not to meet during TPAC, please use the space below.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/not-meeting.yml
+++ b/.github/ISSUE_TEMPLATE/not-meeting.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please use this form to let the W3C staff know your group is not planning to meet during TPAC. The title should be the name of the group. The name must be the official [group name in the W3C system](https://www.w3.org/groups/), with some abbreviations supported (e.g., WG for Working Group). 
+        Please use this form to let the W3C staff know your group is not planning to meet during TPAC. The title should be the name of the group. The name must be the official [group name in the W3C system](https://www.w3.org/groups/), with some abbreviations supported (e.g., WG for Working Group). **Note**: Immediately after you create this issue we will close it; this is intentional.
 
 - type: textarea
     id: comments


### PR DESCRIPTION
To address [issue 248](https://github.com/w3c/tpac-breakouts/issues/248), propose a specific template to indicate a group is not meeting. If this proposal is accepted I will add links for convenience to the readme, and we should send the link to the chairs list as well.